### PR TITLE
Update to new version of ruby-saml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     dotenv (2.1.1)
-    macaddr (1.7.1)
-      systemu (~> 2.6.2)
     metaclass (0.0.4)
     mini_portile2 (2.1.0)
     mocha (1.1.0)
@@ -18,19 +16,15 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    ruby-saml (1.1.0)
+    ruby-saml (1.3.0)
       nokogiri (>= 1.5.10)
-      uuid (~> 2.3)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    systemu (2.6.5)
     test-unit (3.1.8)
       power_assert
     tilt (2.0.2)
-    uuid (2.3.8)
-      macaddr (~> 1.0)
 
 PLATFORMS
   ruby
@@ -47,4 +41,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.12.3
+   1.12.5


### PR DESCRIPTION
**Why:**
- We are using an outdated and insecure version of `ruby-saml`

**How:**
- Update that nonsense.