### PR TITLE
Correctly report SAML auth failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test:
+	bundle exec ruby test/app_test.rb
+
+run:
+	SAML_ENV=local bundle exec ruby app.rb
+
+.PHONY: test run

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-Identity-RP
-===========
+Sinatra-based Identity SP
+=========================
 
-Mock relying party (RP) app for validating IdP and IdV APIs.
-
-May also function as reference RP implementation.
+Example service provide (SP) app for use with 18F's IdP.
 
 ### Setup
 

--- a/views/failure.erb
+++ b/views/failure.erb
@@ -1,0 +1,10 @@
+<div class="clearfix">
+  <div class="col-12 sm-col-6 mx-auto">
+    <div class="h5 p2 bg-red white center">
+      <span class="bold caps">Authentication Failure!</span>
+      <% @errors.each do |err| %>
+        <p><%= err %></strong>.</p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/views/success.erb
+++ b/views/success.erb
@@ -2,9 +2,7 @@
   <div class="col-12 sm-col-6 mx-auto">
     <div class="h5 p2 bg-green white center">
       <span class="bold caps">Success!</span>
-      <% if session[:email] %>
       <span>Your email is <strong><%= session[:email] %></strong>.</span>
-      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**Why**: Previously we were simply reporting success even
when the SAML response was bad.