### PR TITLE
Make one-line deployment possible for -demo and -dev.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,14 @@ May also function as reference RP implementation.
 
     $ bundle exec ruby test/app_test.rb
 
-### Running (development mode)
+### Running (local development mode)
 
     $ SAML_ENV=local bundle exec ruby app.rb
+    
+### Running (on cloud.gov)
+
+    $ bin/cloud_deploy [dev or demo]
+(Note: You'll need to be logged into cloud.gov first)
 
 ### Generating a new key + self-signed cert
 

--- a/app.rb
+++ b/app.rb
@@ -76,8 +76,10 @@ class RelyingParty < Sinatra::Base
   def saml_settings
     if ENV['SAML_ENV'] == 'local'
       settings_file = 'config/saml_settings_local.yml'
+    elsif ENV['SAML_ENV'] == 'dev'
+      settings_file = 'config/saml_settings_dev.yml'
     else
-      settings_file = 'config/saml_settings.yml'
+      settings_file = 'config/saml_settings_demo.yml'
     end
     settings = OneLogin::RubySaml::Settings.new(YAML.load_file settings_file)
     settings.certificate = File.read('config/demo_sp.crt')

--- a/bin/cloud_deploy
+++ b/bin/cloud_deploy
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]
+then
+	echo 'Usage: cloud_deploy [environment]'
+	exit 1
+fi
+
+if [ $1 != 'dev' -a $1 != 'demo' ]
+then
+	echo 'you must specify either dev or demo'
+	exit 1
+fi
+
+cf target -o consumer-identity -s dev
+echo setting up identity-rp-$1
+cf set-env identity-rp-$1 SAML_ENV $1
+cf push identity-rp-$1

--- a/config/saml_settings_demo.yml
+++ b/config/saml_settings_demo.yml
@@ -1,0 +1,15 @@
+assertion_consumer_service_url: https://identity-rp-demo.apps.cloud.gov/consume
+assertion_consumer_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
+issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:demo
+idp_sso_target_url: https://upaya-idp-demo.18f.gov/api/saml/auth
+idp_slo_target_url: https://upaya-idp-demo.18f.gov/api/saml/logout
+idp_cert_fingerprint: 8B:D5:C2:E8:9A:2B:CE:B7:4B:95:50:BA:16:79:05:27:17:D1:D3:67
+name_identifier_format: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+authn_context: http://idmanagement.gov/ns/assurance/loa/1
+single_signon_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
+allowed_clock_drift: 60
+security:
+  authn_requests_signed: true
+  embed_sign: true
+  digest_method: http://www.w3.org/2001/04/xmlenc#sha256
+  signature_method: http://www.w3.org/2001/04/xmldsig-more#rsa-sha256

--- a/config/saml_settings_dev.yml
+++ b/config/saml_settings_dev.yml
@@ -1,8 +1,8 @@
 assertion_consumer_service_url: https://identity-rp-dev.apps.cloud.gov/consume
 assertion_consumer_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev
-idp_sso_target_url: https://upaya-idp-demo.18f.gov/api/saml/auth
-idp_slo_target_url: https://upaya-idp-demo.18f.gov/api/saml/logout
+idp_sso_target_url: https://upaya-idp-dev.18f.gov/api/saml/auth
+idp_slo_target_url: https://upaya-idp-dev.18f.gov/api/saml/logout
 idp_cert_fingerprint: 8B:D5:C2:E8:9A:2B:CE:B7:4B:95:50:BA:16:79:05:27:17:D1:D3:67
 name_identifier_format: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
 authn_context: http://idmanagement.gov/ns/assurance/loa/1


### PR DESCRIPTION
**Why:**
- Currently, there's no automated way of deploying to identity-rp-dev or identity-pr-demo.
- Ensuring same settings are correct for the environment is error-prone.

**How:**
- Split `saml_settings.yml` into three env-appropriate files.
- Add `bin/cloud_deploy` script that sets up config and pushes to cloud.gov.
- Default to -demo.