### PR TITLE
Add SLO, fix session on redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
-ruby '2.3.0'
+ruby '2.3.1'
 
+gem 'hashie'
 gem 'mocha'
 gem 'ruby-saml'
 gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     dotenv (2.1.1)
+    hashie (3.4.4)
     metaclass (0.0.4)
     mini_portile2 (2.1.0)
     mocha (1.1.0)
@@ -31,6 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
+  hashie
   mocha
   rack-test
   ruby-saml

--- a/config/saml_settings_demo.yml
+++ b/config/saml_settings_demo.yml
@@ -10,6 +10,7 @@ single_signon_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 allowed_clock_drift: 60
 security:
   authn_requests_signed: true
+  logout_requests_signed: true
   embed_sign: true
   digest_method: http://www.w3.org/2001/04/xmlenc#sha256
   signature_method: http://www.w3.org/2001/04/xmldsig-more#rsa-sha256

--- a/config/saml_settings_dev.yml
+++ b/config/saml_settings_dev.yml
@@ -10,6 +10,7 @@ single_signon_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 allowed_clock_drift: 60
 security:
   authn_requests_signed: true
+  logout_requests_signed: true
   embed_sign: true
   digest_method: http://www.w3.org/2001/04/xmlenc#sha256
   signature_method: http://www.w3.org/2001/04/xmldsig-more#rsa-sha256

--- a/config/saml_settings_local.yml
+++ b/config/saml_settings_local.yml
@@ -10,6 +10,7 @@ single_signon_service_binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 allowed_clock_drift: 60
 security:
   authn_requests_signed: true
+  logout_requests_signed: true
   embed_sign: true
   digest_method: http://www.w3.org/2001/04/xmlenc#sha256
   signature_method: http://www.w3.org/2001/04/xmldsig-more#rsa-sha256

--- a/views/agency/ed/index.erb
+++ b/views/agency/ed/index.erb
@@ -7,6 +7,15 @@
   <link href="/css/lib/basscss.min.css" rel="stylesheet">
 </head>
 <body>
+  <% if logout_msg %>
+   <div class="logout">
+    <% if logout_msg == 'ok' %>
+      <div class="h5 p2 bg-green white center">You have been logged out.</div>
+    <% else %>
+      <div class="h5 p2 bg-red white center"Logout failed!</div>
+    <% end %>
+   </div>
+  <% end %>
   <div class="container">
     <div class="clearfix py1">
       <div class="sm-col">

--- a/views/agency/ed/success.erb
+++ b/views/agency/ed/success.erb
@@ -11,6 +11,9 @@
     <span class="bold caps">Success!</span>
     <% if session[:email] %>
     <span>Your email is <strong><%= session[:email] %></strong></span>
+    <form action="/logout" method="POST">
+      <button type="submit" class="btn btn-outline bg-white navy">Logout</button>
+    </form>
     <% end %>
   </div>
   <div class="container">

--- a/views/agency/sba/index.erb
+++ b/views/agency/sba/index.erb
@@ -13,6 +13,15 @@
   </style>
 </head>
 <body class="bg-silver">
+  <% if logout_msg %>
+   <div class="logout">
+    <% if logout_msg == 'ok' %>
+      <div class="h5 p2 bg-green white center">You have been logged out.</div>
+    <% else %>
+      <div class="h5 p2 bg-red white center"Logout failed!</div>
+    <% end %>
+   </div>
+  <% end %>
   <div class="container bg-white">
     <div class="border-top page-border p1 sm-show">
       <div class="right">

--- a/views/agency/sba/success.erb
+++ b/views/agency/sba/success.erb
@@ -18,6 +18,9 @@
       <span class="bold caps">Success!</span>
       <% if session[:email] %>
       <span>Your email is <strong><%= session[:email] %></strong></span>
+      <form action="/logout" method="POST">
+        <button type="submit" class="btn btn-outline bg-white navy">Logout</button>
+      </form>
       <% end %>
     </div>
     <div class="border-top page-border p1 sm-show">

--- a/views/agency/uscis/index.erb
+++ b/views/agency/uscis/index.erb
@@ -14,6 +14,15 @@
   </style>
 </head>
 <body>
+  <% if logout_msg %>
+   <div class="logout">
+    <% if logout_msg == 'ok' %>
+      <div class="h5 p2 bg-green white center">You have been logged out.</div>
+    <% else %>
+      <div class="h5 p2 bg-red white center"Logout failed!</div>
+    <% end %>
+   </div>
+  <% end %>
   <div class="relative bg-navy white px2 py1 clearfix">
     <div class="container sm-show">
       <div class="sm-col-right">

--- a/views/agency/uscis/success.erb
+++ b/views/agency/uscis/success.erb
@@ -17,6 +17,9 @@
     <span class="bold caps">Success!</span>
     <% if session[:email] %>
     <span>Your email is <strong><%= session[:email] %></strong></span>
+    <form action="/logout" method="POST">
+      <button type="submit" class="btn btn-outline bg-white navy">Logout</button>
+    </form>
     <% end %>
   </div>
   <div class="relative bg-navy white px2 py1 clearfix">

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,4 +1,13 @@
 <div class="py1 mb3 center">
+  <% if logout_msg %>
+   <div class="logout">
+    <% if logout_msg == 'ok' %>
+      You have been logged out.
+    <% else %>
+      Logout failed!
+    <% end %>
+   </div>
+  <% end %>
   <h2>Please log in to continue.</h2>
   <form action="/login" method="POST">
     <button type="submit" class="btn btn-outline bg-white navy">

--- a/views/success.erb
+++ b/views/success.erb
@@ -3,6 +3,11 @@
     <div class="h5 p2 bg-green white center">
       <span class="bold caps">Success!</span>
       <span>Your email is <strong><%= session[:email] %></strong>.</span>
+      <% if session[:userid] %>
+      <form action="/logout" method="POST">
+        <button type="submit" class="btn btn-outline bg-white navy">Logout</button>
+      </form>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**Why**: Adds example of SP-initiated logout, as well as fixing
some bugs with SAML settings.

**How**:

* SAML settings must use symbolized keys. Hashie::Mash does this for cheap.
* SLO implemented with ruby-saml