### PR TITLE
Use instance variable for var in view template

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -1,5 +1,5 @@
 <div class="py1 mb3 center">
-  <% if logout_msg %>
+  <% if @logout_msg %>
    <div class="logout">
     <% if logout_msg == 'ok' %>
       You have been logged out.


### PR DESCRIPTION
When deploying I noticed the following error: 

```
NameError - undefined local variable or method `logout_msg' for #<RelyingParty:0x007f1d76a90a20>
Did you mean?  logout_session:
/srv/sp-sinatra/releases/20160804220401/views/index.erb:2:in `block in singleton class'
/srv/sp-sinatra/releases/20160804220401/views/index.erb:-6:in `instance_eval'
/srv/sp-sinatra/releases/20160804220401/views/index.erb:-6:in `singleton class'
/srv/sp-sinatra/releases/20160804220401/views/index.erb:-8:in `__tilt_69882254944420'
```

I modified the template to use the instance variable that was declared in `app.rb`. I haven't worked with Sinatra in awhile so I'm not sure if this is the best method to pass vars into a template.