### PR TITLE
Write deploy.json file

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,4 +28,29 @@ namespace :deploy do
       execute :touch, release_path.join('tmp/restart.txt')
     end
   end
+
+  desc 'Write deploy information to deploy.json'
+  task :deploy_json do
+    on roles(:app, :web), in: :parallel do
+      require 'stringio'
+
+      within current_path do
+        deploy = {
+          env: fetch(:stage),
+          branch: fetch(:branch),
+          user: fetch(:local_user),
+          sha: fetch(:current_revision),
+          timestamp: fetch(:release_timestamp)
+        }
+
+        execute :mkdir, '-p', 'public/api'
+
+        # the #upload! method does not honor the values of #within at the moment
+        # https://github.com/capistrano/sshkit/blob/master/EXAMPLES.md#upload-a-file-from-a-stream
+        upload! StringIO.new(deploy.to_json), "#{current_path}/public/api/deploy.json"
+      end
+    end
+  end
+
+  after 'deploy:log_revision', :deploy_json
 end


### PR DESCRIPTION
**Why**:
so we can expose the status of this deploy in our dashboard


(sinatra defaults to exposing files in the `public` directory too, yay! http://www.sinatrarb.com/intro.html#Static%20Files)